### PR TITLE
Add missing field to zeekhttp ax

### DIFF
--- a/zeek/zeek.ax
+++ b/zeek/zeek.ax
@@ -36,7 +36,7 @@
 	desc="Zeek http logs"
 	module="fields"
 	args='-d "\t"'
-	params="ts, uid, orig, orig_port, resp, resp_port, trans_depth, method, host, uri, referrer, version, user_agent, request_body_len, response_body_len, status_code, status_msg, info_code, info_msg, tags, username, password, proxied, orig_fuids, orig_filenames, orig_mime_types, resp_fuids, resp_filenames, resp_mime_types"
+	params="ts, uid, orig, orig_port, resp, resp_port, trans_depth, method, host, uri, referrer, version, user_agent, origin, request_body_len, response_body_len, status_code, status_msg, info_code, info_msg, tags, username, password, proxied, orig_fuids, orig_filenames, orig_mime_types, resp_fuids, resp_filenames, resp_mime_types"
 
 [[extraction]]
 	tag="zeekssl"


### PR DESCRIPTION
Add `origin` field, per https://docs.zeek.org/en/current/scripts/base/protocols/http/main.zeek.html#type-HTTP::Info